### PR TITLE
Deletes nested folders while moving license data and config.

### DIFF
--- a/MarkdownMonster/_Classes/Configuration/ApplicationConfiguration.cs
+++ b/MarkdownMonster/_Classes/Configuration/ApplicationConfiguration.cs
@@ -277,7 +277,7 @@ namespace MarkdownMonster
                         file.CopyTo(Path.Combine(CommonFolder, file.Name), true);
                         file.Delete();
                     }
-                    dir.Delete();
+                    dir.Delete(true);
                 }
             }
             catch(Exception ex)


### PR DESCRIPTION
I had a folder named "Markdown Monster Weblog Posts" in the previous "West Wind Markdown Monster". The folder delete operation without recursive delete could not delete it and was throwing an exception.

For me this fixed #35 as well, but I'm not sure if this is an acceptable fix for the issue. It might be still nice to ask for a new license key when the current one is invalid somehow.