### PR TITLE
Fix position of TabItem context menu

### DIFF
--- a/MarkdownMonster/App.xaml
+++ b/MarkdownMonster/App.xaml
@@ -1,7 +1,6 @@
 ﻿<Application x:Class="MarkdownMonster.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:MarkdownMonster"
              xmlns:dragablz="http://dragablz.net/winfx/xaml/dragablz"                 
              StartupUri="MainWindow.xaml"             
              >
@@ -29,9 +28,12 @@
             </ResourceDictionary.MergedDictionaries>
 
             <!--<Style TargetType="{x:Type dragablz:TabablzControl}" BasedOn="{StaticResource MahAppsTabablzControlStyle}">-->
+            <Style x:Key="MarkdownMonsterTrapezoidDragableTabItemStyle" TargetType="{x:Type dragablz:DragablzItem}" BasedOn="{StaticResource TrapezoidDragableTabItemStyle}">
+                <Setter Property="ContextMenu" Value="{DynamicResource TabItemContextMenu}" />
+            </Style>
+
             <Style TargetType="{x:Type dragablz:TabablzControl}" BasedOn="{StaticResource {x:Type dragablz:TabablzControl}}">
-            
-                <Setter Property="ItemContainerStyle" Value="{StaticResource TrapezoidDragableTabItemStyle}" />
+                <Setter Property="ItemContainerStyle" Value="{StaticResource MarkdownMonsterTrapezoidDragableTabItemStyle}" />
                 <Setter Property="AdjacentHeaderItemOffset" Value="-12" />
                 <Setter Property="ShowDefaultAddButton" Value="True" />
                 <Setter Property="ShowDefaultCloseButton" Value="True" />

--- a/MarkdownMonster/MainWindow.xaml
+++ b/MarkdownMonster/MainWindow.xaml
@@ -81,7 +81,7 @@
 
     <Window.Resources>
         <ContextMenu x:Key="TabItemContextMenu" Name="TabItemContextMenu">
-            <MenuItem Header="_Close Document" Command="{Binding CloseActiveDocumentCommand}" />
+            <MenuItem Header="_Close Document" Command="{Binding DataContext.CloseActiveDocumentCommand}" />
             <MenuItem Name="MenuCloseAllTabs" Header="Close All Documents" Click="ButtonCloseAllTabs_Click"/>
             <MenuItem Name="MenuCloseAllButThisTab" Header="Close All But This Document" Click="ButtonCloseAllTabs_Click"/>
             <Separator/>

--- a/MarkdownMonster/MainWindow.xaml
+++ b/MarkdownMonster/MainWindow.xaml
@@ -424,19 +424,16 @@
                 <ColumnDefinition Width="0" />
             </Grid.ColumnDefinitions>
 
+            <dragablz:TabablzControl x:Name="TabControl"
+                                     Margin="0,5,0,0"
+                                     FontSize="13"
+                                     Background="#222"
+                                     BorderThickness="0"
+                                     ShowDefaultCloseButton="True"
+                                     ShowDefaultAddButton="False"
+                                     SelectionChanged="TabControl_SelectionChanged" />
 
-                <dragablz:TabablzControl x:Name="TabControl" Margin="0,5,0,0" FontSize="13" Background="#222"
-                                 BorderThickness="0" ShowDefaultCloseButton="True" 
-                                 ShowDefaultAddButton="False" 
-                                 SelectionChanged="TabControl_SelectionChanged"      
-                                 ContextMenu="{StaticResource TabItemContextMenu}"    
-                                 ContextMenuService.Placement="MousePoint"                                         
-                                 ContextMenuService.HorizontalOffset="80"
-                                 ContextMenuService.VerticalOffset="16"                                          
-                                 />
-
-
-                <GridSplitter Grid.Column="1"                          
+            <GridSplitter Grid.Column="1"                          
                           Width="12"                          
                           HorizontalAlignment="Center"                          
                           BorderThickness="0"
@@ -524,3 +521,4 @@
         </StatusBar>
     </Grid>
 </controls:MetroWindow>
+

--- a/MarkdownMonster/MainWindow.xaml.cs
+++ b/MarkdownMonster/MainWindow.xaml.cs
@@ -509,8 +509,6 @@ namespace MarkdownMonster
             tab.Margin = new Thickness(0, 0, 3, 0);
             tab.Padding = new Thickness(2, 0, 7, 2);            
             tab.Background = Background;
-            tab.ContextMenu = Resources["TabItemContextMenu"] as ContextMenu;
-            
 
             ControlsHelper.SetHeaderFontSize(tab, 13F);
 

--- a/MarkdownMonster/MainWindow.xaml.cs
+++ b/MarkdownMonster/MainWindow.xaml.cs
@@ -520,7 +520,6 @@ namespace MarkdownMonster
             
             tab.Content = wb;
 
-
             if (editor == null)
             {
                 editor = new MarkdownDocumentEditor(wb)

--- a/MarkdownMonster/Styles/MahMenuCustomizations.xaml
+++ b/MarkdownMonster/Styles/MahMenuCustomizations.xaml
@@ -32,7 +32,11 @@
     </Style>
     
     <Style TargetType="{x:Type MenuItem}">
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="{StaticResource Foreground}" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type MenuItem}">
@@ -41,7 +45,7 @@
                             Background="Transparent"
                             BorderBrush="Transparent"
                             BorderThickness="1"
-                            SnapsToDevicePixels="False">
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                         <Grid x:Name="Grid">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition x:Name="Col0"
@@ -81,7 +85,6 @@
                                    AllowsTransparency="True"
                                    Focusable="false"
                                    HorizontalOffset="-1"
-                                   
                                    IsOpen="{Binding Path=IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}"
                                    Placement="Right"
                                    PopupAnimation="{DynamicResource {x:Static SystemParameters.MenuPopupAnimationKey}}">
@@ -91,7 +94,7 @@
                                             Background="{StaticResource SubmenuItemBackground}"
                                             BorderBrush="{StaticResource MenuSeparatorBorderBrush}"
                                             BorderThickness="1"
-                                            SnapsToDevicePixels="True">
+                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                                         <Grid x:Name="SubMenu"
                                               Margin="2"
                                               Grid.IsSharedSizeScope="True">
@@ -101,17 +104,6 @@
                                             <DropShadowEffect ShadowDepth="2" Color="Black" />
                                         </Border.Effect>
                                     </Border>
-                                    <!--  Border 3  -->
-                                    <Border x:Name="TransitionBorder"
-                                            Width="0"
-                                            Height="2"
-                                            Margin="1 0 0 0"
-                                            HorizontalAlignment="Left"
-                                            VerticalAlignment="Top"
-                                            Background="{StaticResource SubmenuItemBackground}"
-                                            BorderBrush="{StaticResource  MenuSeparatorBorderBrush}"
-                                            BorderThickness="1"
-                                            SnapsToDevicePixels="False" />
                                 </Grid>
                             </Popup>
                         </Grid>
@@ -127,7 +119,6 @@
                             <Setter TargetName="SubMenu" Property="Margin" Value="2 3 2 2" />
                             <Setter TargetName="SubMenuBorder" Property="BorderThickness" Value="1 1 1 1" />
                             <Setter TargetName="SubMenuPopup" Property="Placement" Value="Bottom" />
-                            <Setter TargetName="TransitionBorder" Property="Width" Value="{Binding ActualWidth, ElementName=Grid}" />
                         </Trigger>
                         <Trigger Property="Role" Value="TopLevelItem">
                             <Setter Property="Padding" Value="6 0 6 2" />
@@ -140,14 +131,14 @@
                         <Trigger Property="Role" Value="SubmenuHeader">
                             <Setter Property="DockPanel.Dock" Value="Top" />
                             <Setter Property="Padding" Value="10 3 0 3" />
-                            <Setter TargetName="Border" Property="Background" Value="{StaticResource SubmenuItemBackground}" />
+                            <Setter Property="Background" Value="{StaticResource SubmenuItemBackground}" />
                             <Setter TargetName="Border" Property="MinHeight" Value="22" />
                         </Trigger>
                         <Trigger Property="Role" Value="SubmenuItem">
                             <Setter Property="DockPanel.Dock" Value="Top" />
                             <Setter Property="Padding" Value="10 3 0 3" />
                             <Setter TargetName="ArrowPanel" Property="Visibility" Value="Collapsed" />
-                            <Setter TargetName="Border" Property="Background" Value="{StaticResource SubmenuItemBackground}" />
+                            <Setter Property="Background" Value="{StaticResource SubmenuItemBackground}" />
                             <Setter TargetName="Border" Property="MinHeight" Value="22" />
                         </Trigger>
                         <MultiTrigger>


### PR DESCRIPTION
@RickStrahl We saw this at summit and now I have a fix for it :-D

- Binding to the close command is also fixed
- MenuItem Background for context menu fixed

**Before**

![image](https://cloud.githubusercontent.com/assets/658431/21712865/51077ba0-d3f7-11e6-91b2-a44e3515ea38.png)

![image](https://cloud.githubusercontent.com/assets/658431/21712869/5379e918-d3f7-11e6-9946-7a3e072df791.png)

**After**

![image](https://cloud.githubusercontent.com/assets/658431/21712870/5725cd48-d3f7-11e6-9857-bec3e456750b.png)

![image](https://cloud.githubusercontent.com/assets/658431/21712875/595f9eea-d3f7-11e6-98be-b1fbffd04317.png)

**Background fix**

![image](https://cloud.githubusercontent.com/assets/658431/21713790/f522d6ea-d3fb-11e6-9912-3ea7688205ad.png)
