### PR TITLE
Improvements for the parser addin feature

### DIFF
--- a/MarkdownMonster/AppModel.cs
+++ b/MarkdownMonster/AppModel.cs
@@ -275,22 +275,22 @@ namespace MarkdownMonster
         }
         private List<string> _parserNames;
 
+        /// <summary>
+        /// Returns the width of the column containing
+        /// the Markdown Parser selection combo box
+        /// </summary>
         public int MarkdownParserColumnWidth
         {
             get
             {
                 if (AddinManager.Current
-                    .AddIns
-                    .Where(ai => ai.GetMarkdownParser() != null)
+                    .GetMarkDownParserAddins()
                     .Count() > 0)
                 {
                     return 130;
                 }
-                else
-                {
-                    return 0;
-                }
                 
+                return 0;
             }
         }
 

--- a/MarkdownMonster/AppModel.cs
+++ b/MarkdownMonster/AppModel.cs
@@ -275,6 +275,25 @@ namespace MarkdownMonster
         }
         private List<string> _parserNames;
 
+        public int MarkdownParserColumnWidth
+        {
+            get
+            {
+                if (AddinManager.Current
+                    .AddIns
+                    .Where(ai => ai.GetMarkdownParser() != null)
+                    .Count() > 0)
+                {
+                    return 130;
+                }
+                else
+                {
+                    return 0;
+                }
+                
+            }
+        }
+
         #region Initialization
 
         public AppModel(MainWindow window)

--- a/MarkdownMonster/MainWindow.xaml
+++ b/MarkdownMonster/MainWindow.xaml
@@ -473,8 +473,9 @@
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="4"  />
                             <ColumnDefinition Width="230"  />
-                            <ColumnDefinition Width="100"  />
-                            <ColumnDefinition Width="130"  />
+                            <ColumnDefinition Width="100"/>
+                            <!-- Markdown Parser column, width = 130 -->
+                            <ColumnDefinition Width="{Binding MarkdownParserColumnWidth}"/>
                             <ColumnDefinition Width="130" />
                             <ColumnDefinition Width="130" />
                             <ColumnDefinition Width="Auto" />

--- a/MarkdownMonster/MainWindow.xaml.cs
+++ b/MarkdownMonster/MainWindow.xaml.cs
@@ -65,7 +65,7 @@ namespace MarkdownMonster
 
         private NamedPipeManager PipeManager { get; set; }
 
-        public ApplicationConfiguration Configuration { get; set; }
+        //public ApplicationConfiguration Configuration { get; set; }
 
         public IntPtr Hwnd
         {
@@ -1470,8 +1470,11 @@ namespace MarkdownMonster
 
         private void MarkdownParserName_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (Configuration != null && !string.IsNullOrEmpty(Configuration.MarkdownParserName))
-                MarkdownParserFactory.GetParser(addinId: Configuration.MarkdownParserName, forceLoad: true);
+            if (mmApp.Configuration != null && !string.IsNullOrEmpty(mmApp.Configuration.MarkdownParserName))
+            {
+                MarkdownParserFactory.GetParser(addinId: mmApp.Configuration.MarkdownParserName, forceLoad: true);
+                PreviewMarkdownAsync();
+            }
         }
 
 

--- a/MarkdownMonster/MainWindow.xaml.cs
+++ b/MarkdownMonster/MainWindow.xaml.cs
@@ -205,7 +205,8 @@ namespace MarkdownMonster
                     AddinManager.Current.LoadAddins(mmApp.Configuration.AddinsFolder);
                     AddinManager.Current.AddinsLoadingComplete = true;
                     Model.OnPropertyChanged(nameof(AppModel.MarkdownParserNames));
-                    
+                    Model.OnPropertyChanged(nameof(AppModel.MarkdownParserColumnWidth));
+
                     try
                     {
                         AddinManager.Current.RaiseOnApplicationStart();

--- a/MarkdownMonster/_Classes/AddInInterfaces/AddinManager.cs
+++ b/MarkdownMonster/_Classes/AddInInterfaces/AddinManager.cs
@@ -879,7 +879,10 @@ namespace MarkdownMonster.AddIns
 
             return true;
         }
-
+        /// <summary>
+        /// Returns an IEnumerable<MarkdownMonsterAddin> containing
+        /// loaded MarkDown parser addins
+        /// </summary>
         public IEnumerable<MarkdownMonsterAddin> GetMarkDownParserAddins()
         {
             return AddIns.Where(ai => ai.GetMarkdownParser() != null);

--- a/MarkdownMonster/_Classes/AddInInterfaces/AddinManager.cs
+++ b/MarkdownMonster/_Classes/AddInInterfaces/AddinManager.cs
@@ -880,6 +880,10 @@ namespace MarkdownMonster.AddIns
             return true;
         }
 
+        public IEnumerable<MarkdownMonsterAddin> GetMarkDownParserAddins()
+        {
+            return AddIns.Where(ai => ai.GetMarkdownParser() != null);
+        }
         #endregion
     }
 }

--- a/MarkdownMonster/_Classes/MarkdownParser/MarkdownParserFactory.cs
+++ b/MarkdownMonster/_Classes/MarkdownParser/MarkdownParserFactory.cs
@@ -10,6 +10,8 @@ namespace MarkdownMonster
     public static class MarkdownParserFactory
     {
 
+        public static readonly string DefaultMarkdownParserName = "MarkDig";
+
         /// <summary>
         /// Use a cached instance of the Markdown Parser to keep alive
         /// </summary>
@@ -31,7 +33,7 @@ namespace MarkdownMonster
 
             IMarkdownParser parser = null;
 
-            if (!string.IsNullOrEmpty(addinId) && addinId != "MarkDig")
+            if (!string.IsNullOrEmpty(addinId) && addinId != DefaultMarkdownParserName)
             {
                 var addin = AddinManager.Current.AddIns.FirstOrDefault(a => a.Name == addinId || a.Id == addinId);
                 if (addin != null)

--- a/MarkdownMonster/_Classes/MarkdownParser/MarkdownParserFactory.cs
+++ b/MarkdownMonster/_Classes/MarkdownParser/MarkdownParserFactory.cs
@@ -55,7 +55,7 @@ namespace MarkdownMonster
             
             var parserStrings = new List<string>()
             {
-                {"MarkDig"}
+                {DefaultMarkdownParserName}
             };
 
             if (AddinManager.Current.AddIns.Count == 0)

--- a/Tests/MarkdownMonster.Test/MarkdownMonster.Test.csproj
+++ b/Tests/MarkdownMonster.Test/MarkdownMonster.Test.csproj
@@ -72,6 +72,7 @@
     <Compile Include="MarkdownTests.cs" />
     <Compile Include="ActiveDocumentTests.cs" />
     <Compile Include="ClipboardTests.cs" />
+    <Compile Include="MarkdownParserFactoryTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Tests/MarkdownMonster.Test/MarkdownParserFactoryTest.cs
+++ b/Tests/MarkdownMonster.Test/MarkdownParserFactoryTest.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace MarkdownMonster.Test
+{
+    [TestClass]
+    public class MarkdownParserFactoryTest
+    {
+        [TestMethod]
+        public void ShouldReturnListOfParserNamesContainingTheDefaultParserNameWhenNoAddinsLoaded()
+        {
+            var names = MarkdownParserFactory.GetParserNames();
+            Assert.AreEqual(1, names.Count);
+            Assert.AreEqual(MarkdownParserFactory.DefaultMarkdownParserName, names.First());
+        }
+    }
+}

--- a/Tests/MarkdownMonster.Test/MarkdownParserFactoryTest.cs
+++ b/Tests/MarkdownMonster.Test/MarkdownParserFactoryTest.cs
@@ -1,18 +1,120 @@
-﻿using System;
+﻿using System.Linq;
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Linq;
 
 namespace MarkdownMonster.Test
 {
     [TestClass]
     public class MarkdownParserFactoryTest
     {
+        [TestCleanup]
+        public void TearDown()
+        {
+            AddIns.AddinManager.Current.AddIns.Clear();
+            MarkdownParserFactory.CurrentParser = null;
+        }
+
         [TestMethod]
         public void ShouldReturnListOfParserNamesContainingTheDefaultParserNameWhenNoAddinsLoaded()
         {
-            var names = MarkdownParserFactory.GetParserNames();
+            List<string> names = MarkdownParserFactory.GetParserNames();
             Assert.AreEqual(1, names.Count);
             Assert.AreEqual(MarkdownParserFactory.DefaultMarkdownParserName, names.First());
+        }
+
+        [TestMethod]
+        public void ShouldReturnListOfParserNamesLoaded()
+        {
+            _loadAddin(new CustomParserAddin());
+
+            var names = MarkdownParserFactory.GetParserNames();
+            Assert.AreEqual(2, names.Count);
+
+            CollectionAssert.AreEqual(new List<string> { MarkdownParserFactory.DefaultMarkdownParserName, "CustomParser" }, names);
+        }
+
+        [TestMethod]
+        public void ShouldReturnTheDefaultParserWhenNoArgsGiven()
+        {
+
+            var parser = MarkdownParserFactory.GetParser();
+            Assert.IsInstanceOfType(parser, typeof(MarkdownParserMarkdig));
+        }
+
+        [TestMethod]
+        public void ShouldReturnTheSpecifiedParser()
+        {
+            _loadAddin(new CustomParserAddin());
+
+            var parser = MarkdownParserFactory.GetParser(addinId: "CustomParser");
+            Assert.IsInstanceOfType(parser, typeof(CustomParser));
+        }
+
+        [TestMethod]
+        public void ShouldReturnTheCachedParserWhenForceLoadArgIsFalse()
+        {
+            _loadAddin(new CustomParserAddin());
+
+            MarkdownParserFactory.GetParser();
+            var parser = MarkdownParserFactory.GetParser(forceLoad: false, addinId: "CustomParser");
+            Assert.IsInstanceOfType(parser, typeof(MarkdownParserMarkdig));
+        }
+
+        [TestMethod]
+        public void ShouldReturnTheSpecifiedParserWhenForceLoadArgIsTrue()
+        {
+            _loadAddin(new CustomParserAddin());
+
+            MarkdownParserFactory.GetParser();
+            var parser = MarkdownParserFactory.GetParser(forceLoad: true, addinId: "CustomParser");
+            Assert.IsInstanceOfType(parser, typeof(CustomParser));
+        }
+
+        [TestMethod]
+        public void ShouldReturnTheDefaultMarkdownParserWhenUnkownParserNameGiven()
+        {
+            var parser = MarkdownParserFactory.GetParser(addinId: "BogusParser");
+            Assert.IsInstanceOfType(parser, typeof(MarkdownParserMarkdig));
+        }
+
+        [TestMethod]
+        public void ShouldFetchAddinParserByAddinId()
+        {
+            _loadAddin(new CustomParserAddin());
+            var parser = MarkdownParserFactory.GetParser(addinId: "CustomParserAddin");
+            Assert.IsInstanceOfType(parser, typeof(CustomParser));
+        }
+        private void _loadAddin(AddIns.MarkdownMonsterAddin addin)
+        {
+            AddIns.AddinManager.Current.AddIns.Add(addin);
+            foreach (var ai in AddIns.AddinManager.Current.AddIns)
+            {
+                ai.OnApplicationStart();
+            }
+        }
+        
+    }
+
+    class CustomParserAddin : AddIns.MarkdownMonsterAddin
+    {
+
+        public override void OnApplicationStart()
+        {
+            Id = "CustomParserAddin";
+            Name = "CustomParser";
+        }
+
+        public override IMarkdownParser GetMarkdownParser()
+        {
+            return new CustomParser();
+        }
+    }
+
+    class CustomParser : IMarkdownParser
+    {
+        public string Parse(string markdown, bool renderLinksExternal = false)
+        {
+            return string.Empty;
         }
     }
 }


### PR DESCRIPTION
## Selecting a parser regenerates the preview
A call to `MainWindows.PreviewMarkdownAsync` has been added to the `MainWindow.MarkdownParserName_SelectionChanged` method in order to regenerate the preview html with the selected parser.

Note that the usage of the `Configuration` property as been replaced by `mmApp.Configuration` since the latter contains the actual configuration data.

Furthermore, the `MainWindow.Configuration` property has been commented out since it is basically unused.

## Parser selection combo box is only visible when multiple parsers are loaded

When there is only one parser available (the default MarkDig Parser), the parser selection combo box will be hidden.
This is achieved by binding the width of the grid column containing the parser selection combo box to the `AppModel.MarkdownParserColumnWidth` property which returns `0` when no Parser addins are loaded.

## Test case for the MarkdownParserFactory class
The `MarkdownParserFactoryTest` test class exercising the `MarkdownParserFactory` class has been added.
It might be useful for future refactoring and regression testing.