### PR TITLE
Improve post metadata reading and writing

### DIFF
--- a/AddIns/WebLogAddin/WebLogAddin.cs
+++ b/AddIns/WebLogAddin/WebLogAddin.cs
@@ -335,32 +335,7 @@ namespace WeblogAddin
 
 {meta.MarkdownBody}
 
-<!-- Post Configuration -->
-<!--
-```xml
-<blogpost>
-<title>{meta.Title}</title>
-<abstract>
-{meta.Abstract}
-</abstract>
-<categories>
-{meta.Categories}
-</categories>
-<isDraft>{meta.IsDraft}</isDraft>
-<featuredImage>{meta.FeaturedImageUrl}</featuredImage>
-<keywords>
-{meta.Keywords}
-</keywords>
-<weblogs>
-<postid>{meta.PostId}</postid>
-<weblog>
-{meta.WeblogName}
-</weblog>
-</weblogs>
-</blogpost>
-```
--->
-<!-- End Post Configuration -->
+{meta.SetConfigInMarkdown()}
 ";
 
             if (WeblogAddinConfiguration.Current.AddFrontMatterToNewBlogPost)
@@ -414,22 +389,6 @@ namespace WeblogAddin
                 return true;
 
             return false;
-        }
-
-        /// <summary>
-        /// Adds a post id to Weblog configuration in a weblog post document.
-        /// Only works if [categories] key exists.
-        /// </summary>
-        /// <param name="markdown"></param>
-        /// <param name="postId"></param>
-        /// <returns></returns>
-        public string AddPostId(string markdown, int postId)
-        {
-            markdown = markdown.Replace("</categories>",
-                    "</categories>\r\n" +
-                    "<postid>" + WeblogModel.ActivePost.PostID + "</postid>");
-
-            return markdown;
         }
 
         #endregion


### PR DESCRIPTION
Use Linq to XML rather than delimiters and string formatting.

The current code for parsing post metadata is brittle and likely to fail if the metadata is edited by hand:
- it requires the XML to not be indented (because it looks for elements at the start of the line)
- it ignores XML semantics, and could recognize wrong inserted elements (e.g. an element with the path `/blogpost/foo/title` would be treated the same as `/blogpost/title`)
- it would not recognize `true` as true, because it expects `True` (case sensitive)

I changed all this code to use Linq to XML instead. Since I was at it, I also updated the code that generates the XML to use Linq to XML instead.