### PR TITLE
Add missing mapping for Post.Url

### DIFF
--- a/AddIns/WebLogAddin/MetaWebLogApi/Mapper.cs
+++ b/AddIns/WebLogAddin/MetaWebLogApi/Mapper.cs
@@ -289,6 +289,7 @@ namespace WebLogAddin.MetaWebLogApi
                     Tags = input.mt_keywords?.Split(','),
                     Title = input.title,
                     Permalink = input.permaLink,
+                    Url = input.link,
                     mt_excerpt = input.mt_excerpt,
                     mt_keywords = input.mt_keywords,
                     wp_post_thumbnail = input.wp_post_thumbnail,


### PR DESCRIPTION
`Post.Url` was never set, causing MM to open the blog home page instead of the post URL.