### PR TITLE
Enable ability for plugins to receive parser configuration variables.

### DIFF
--- a/MarkdownMonster/_Classes/AddInInterfaces/MarkdownMonsterAddin.cs
+++ b/MarkdownMonster/_Classes/AddInInterfaces/MarkdownMonsterAddin.cs
@@ -257,6 +257,19 @@ namespace MarkdownMonster.AddIns
             return null;           
         }
 
+        /// <summary>
+        /// If this addin wants to provide a custom Markdown Parser this method can 
+        /// be overriden to do it.
+        /// </summary>
+        /// <param name="usePragmaLines">If true, pragma line ids should be added into the document
+        /// to support preview synchronization</param>
+        /// <param name="force">Forces the parser to be reloaded - otherwise previously loaded instance can be used</param>
+        /// <returns>IMarkdownParser instance or null. Passed the instance is used for parsing</returns>
+        public virtual IMarkdownParser GetMarkdownParser(bool usePragmaLines, bool force)
+        {
+            // Existing parsers use the older method, so default to calling that.
+            return this.GetMarkdownParser();
+        }
 
         /// <summary>
         /// Called after the addin is initially installed. Use this

--- a/MarkdownMonster/_Classes/MarkdownParser/MarkdownParserFactory.cs
+++ b/MarkdownMonster/_Classes/MarkdownParser/MarkdownParserFactory.cs
@@ -35,7 +35,7 @@ namespace MarkdownMonster
             {
                 var addin = AddinManager.Current.AddIns.FirstOrDefault(a => a.Name == parserAddinId || a.Id == parserAddinId);
                 if (addin != null)
-                    parser = addin.GetMarkdownParser();
+                    parser = addin.GetMarkdownParser(usePragmaLines: usePragmaLines, force: forceLoad);
             }
             
             CurrentParser = parser ?? (parser = new MarkdownParserMarkdig(usePragmaLines: usePragmaLines, force: forceLoad));


### PR DESCRIPTION
Resolves #229. 

Adds an extra method to the base addin class which takes the missing parameters. By default, this delegates to the older method to ensure that existing add-ins continue to see the existing behavior. This enables the creation of parsers which can also respond to the request for pragma lines or forced reload (more specifically, it allows for calling a parser that uses additional extensions or parsing code with markdig while still supporting the ability to have pragma lines).