### PR TITLE
Enable support for enabling built-in markdig extensions

### DIFF
--- a/MarkdownMonster/_Classes/Configuration/MarkdownOptionsConfiguration.cs
+++ b/MarkdownMonster/_Classes/Configuration/MarkdownOptionsConfiguration.cs
@@ -71,6 +71,21 @@ namespace MarkdownMonster
         /// Renders all links as external links with `target='top'`
         /// </summary>
         public bool RenderLinksAsExternal { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Markdig extensions to be enabled.
+        /// </summary>
+        public string MarkdigExtensions
+        {
+            get { return _markdigExtensions; }
+            set
+            {
+                if (value == _markdigExtensions) return;
+                _markdigExtensions = value;
+                OnPropertyChanged();
+            }
+        }
+        private string _markdigExtensions = "emphasisextras+pipetables+gridtables+footers+footnotes+citations+attributes";
         
         #endregion
 

--- a/MarkdownMonster/_Classes/MarkdownParser/MarkdownParserMarkDig.cs
+++ b/MarkdownMonster/_Classes/MarkdownParser/MarkdownParserMarkDig.cs
@@ -90,14 +90,7 @@ namespace MarkdownMonster
 
         protected virtual MarkdownPipelineBuilder CreatePipelineBuilder()
         {
-            var builder = new MarkdownPipelineBuilder()
-                .UseEmphasisExtras()
-                .UsePipeTables()
-                .UseGridTables()
-                .UseFooters()
-                .UseFootnotes()
-                .UseCitations();
-
+            var builder = new MarkdownPipelineBuilder();
 
             var options = mmApp.Configuration.MarkdownOptions;
             if (options.AutoLinks)
@@ -124,6 +117,21 @@ namespace MarkdownMonster
 
             if (_usePragmaLines)
                 builder = builder.UsePragmaLines();
+
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(options.MarkdigExtensions))
+                {
+                    builder = builder.Configure(options.MarkdigExtensions);
+                }
+            }
+            catch(ArgumentException ex)
+            {
+                // One or more of the extension options is invalid. 
+                // Processing of the extensions stopped at this point.
+                // Log an error.
+                mmApp.Log(ex);
+            }
 
             return builder;
         }


### PR DESCRIPTION
Resolves #230. 

Defaults to the existing configuration and behavior plus the ```attributes```` support if the new configuration property is missing. If the property is present but empty, the named extensions are all left unloaded. If the property has values, Markdig will load the specified extensions. This should minimize the need for custom markdig based parsers unless using private extensions.

It is worth noting that this PR logs errors from a bad configuration but does not raise an alert. A message could be added to notify the user that there is an error in the extension list. The message returned on the exception from Markdig would indicate the particular extension that could not be loaded.