### PR TITLE
Fix missing TextBox inheritence

### DIFF
--- a/AddIns/WebLogAddin/WebLogForm.xaml
+++ b/AddIns/WebLogAddin/WebLogForm.xaml
@@ -44,11 +44,11 @@
                                  ShowDefaultAddButton="False" 
                                  >
             <dragablz:TabablzControl.Resources>
-                <Style TargetType="{x:Type TextBox}">
+                <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MetroTextBox}">
                     <Setter Property="FontSize" Value="14" />
                     <Setter Property="Padding" Value="5,3,5,5" />
                 </Style>
-                <Style  x:Key="HeaderStyle" TargetType="{x:Type TextBox}">
+                <Style x:Key="HeaderStyle" TargetType="{x:Type TextBox}" BasedOn="{StaticResource MetroTextBox}">
                     <Setter Property="FontSize" Value="17" />
                     <Setter Property="FontWeight" Value="Bold" />
                     <Setter Property="Foreground" Value="SteelBlue" />

--- a/MarkdownMonster/Windows/FolderBrowserSidebar/FolderBrowerSidebar.xaml
+++ b/MarkdownMonster/Windows/FolderBrowserSidebar/FolderBrowerSidebar.xaml
@@ -33,11 +33,11 @@
                     </TextBlock>
 
                     <TextBox Name="TextEditFileItem"
-                            Text="{Binding EditName, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Padding="6,2,10,2"                            
+                            Text="{Binding EditName, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Padding="6,0,10,0" Margin="0"                            
                             Visibility="{Binding IsEditing, Converter={StaticResource BooleanToVisibilityConverter}}" 
                              LostFocus="TextEditFileItem_LostFocus">
                         <TextBox.Style>
-                            <Style TargetType="TextBox">
+                            <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MetroTextBox}">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsEditing}" Value="True">
                                         <Setter Property="FocusManager.FocusedElement" Value="{Binding RelativeSource={RelativeSource Self}}"/>


### PR DESCRIPTION
You need to inherit from the base/original MahApps style. You can do this

with

```
<Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MetroTextBox}">
...
</Style>
```

or

```
<Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource {x:Type TextBox}}">
...
</Style>
```
