### PR TITLE
Added code to convert theme path to file:/// encoding

### DIFF
--- a/MarkdownMonster/MarkdownMonster.csproj
+++ b/MarkdownMonster/MarkdownMonster.csproj
@@ -196,6 +196,7 @@
     <Compile Include="_Classes\Configuration\FolderBrowserConfiguration.cs" />
     <Compile Include="_Classes\Configuration\MarkdownOptionsConfiguration.cs" />
     <Compile Include="_Classes\Configuration\WindowPositionConfiguration.cs" />
+    <Compile Include="_Classes\MarkdownDocument-Helpersy.cs" />
     <Compile Include="_Classes\Utilities\AssociatedIcons.cs" />
     <Compile Include="_Classes\Utilities\ClipboardHelper.cs" />
     <Compile Include="_Classes\Utilities\DebounceDispatcher.cs" />

--- a/MarkdownMonster/_Classes/MarkdownDocument-Helpersy.cs
+++ b/MarkdownMonster/_Classes/MarkdownDocument-Helpersy.cs
@@ -1,0 +1,63 @@
+﻿#region License
+/*
+ **************************************************************
+ *  Author: Rick Strahl 
+ *          © West Wind Technologies, 2016
+ *          http://www.west-wind.com/
+ * 
+ * Created: 04/28/2016
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************  
+*/
+#endregion
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Threading;
+using Newtonsoft.Json;
+using Westwind.Utilities;
+using System.Linq;
+using System.Security;
+
+namespace MarkdownMonster {
+
+	public partial class MarkdownDocument {
+
+		protected string FixThemePath( string path )
+		{
+			if( string.IsNullOrEmpty( path ) ) {
+				return string.Empty;
+			}
+
+			return $"file:///{path.Replace( '\\', '/' )}";
+
+		}
+
+	}
+}

--- a/MarkdownMonster/_Classes/MarkdownDocument.cs
+++ b/MarkdownMonster/_Classes/MarkdownDocument.cs
@@ -53,7 +53,7 @@ namespace MarkdownMonster
     /// [ComVisible] is important as we access this from JavaScript
     /// </summary>
     [ComVisible(true)]
-    public class MarkdownDocument : INotifyPropertyChanged
+    public partial class MarkdownDocument : INotifyPropertyChanged
     {
         private const string ENCRYPTION_PREFIX = "__ENCRYPTED__";
 
@@ -807,8 +807,8 @@ namespace MarkdownMonster
                 mmApp.Configuration.RenderTheme = "Dharkan";
                 themeHtml = "<html><body><h3>Invalid Theme or missing files. Resetting to Dharkan.</h3></body></html>";
             }
-            var html = themeHtml.Replace("{$themePath}", themePath)
-                .Replace("{$docPath}", docPath)
+            var html = themeHtml.Replace("{$themePath}", FixThemePath( themePath) )
+                .Replace("{$docPath}", FixThemePath( docPath) )
                 .Replace("{$markdownHtml}", markdownHtml);
 
             if (!WriteFile(filename, html))


### PR DESCRIPTION
I discovered that the HTML generated by mm does not display using the current theme when viewed in Firefox (55.0.3); tracked the issue down to Firefox not following local paths "c:\some\path\to\somewhere". I wrote a short method to fix the theme and doc paths, called from RenderHtmlToFile(), you can see the code in diff.

Note even though the paths in the theme files themselves still use the "\xx\yy" notation, Firefox parses them as long as the url starts with file:/// notation.