### PR TITLE
Refactored MarkdownParserMarkDig.cs, Modified MarkdownDocument.cs

### DIFF
--- a/MarkdownMonster.sln
+++ b/MarkdownMonster.sln
@@ -27,28 +27,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkdownMonster.Test", "Tes
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AddIns", "AddIns", "{4F5BF002-399D-4830-BA4E-23EE97D97956}"
 EndProject
-Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "MarkdownMonsterWeb", "MarkdownMonsterWeb\", "{6AB5E445-9660-454B-BF02-506000EED978}"
-	ProjectSection(WebsiteProperties) = preProject
-		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.6"
-		ProjectReferences = ""
-		Debug.AspNetCompiler.VirtualPath = "/localhost_1863"
-		Debug.AspNetCompiler.PhysicalPath = "MarkdownMonsterWeb\"
-		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_1863\"
-		Debug.AspNetCompiler.Updateable = "true"
-		Debug.AspNetCompiler.ForceOverwrite = "true"
-		Debug.AspNetCompiler.FixedNames = "false"
-		Debug.AspNetCompiler.Debug = "True"
-		Release.AspNetCompiler.VirtualPath = "/localhost_1863"
-		Release.AspNetCompiler.PhysicalPath = "MarkdownMonsterWeb\"
-		Release.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_1863\"
-		Release.AspNetCompiler.Updateable = "true"
-		Release.AspNetCompiler.ForceOverwrite = "true"
-		Release.AspNetCompiler.FixedNames = "false"
-		Release.AspNetCompiler.Debug = "False"
-		VWDPort = "1863"
-		SlnRelativePath = "MarkdownMonsterWeb\"
-	EndProjectSection
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -118,16 +96,6 @@ Global
 		{A3FCE345-F767-487F-86BF-DFA78B4BC218}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A3FCE345-F767-487F-86BF-DFA78B4BC218}.SandBox|Any CPU.ActiveCfg = Release|Any CPU
 		{A3FCE345-F767-487F-86BF-DFA78B4BC218}.SandBox|Any CPU.Build.0 = Release|Any CPU
-		{6AB5E445-9660-454B-BF02-506000EED978}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6AB5E445-9660-454B-BF02-506000EED978}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6AB5E445-9660-454B-BF02-506000EED978}.Deploy|Any CPU.ActiveCfg = Debug|Any CPU
-		{6AB5E445-9660-454B-BF02-506000EED978}.Deploy|Any CPU.Build.0 = Debug|Any CPU
-		{6AB5E445-9660-454B-BF02-506000EED978}.net40|Any CPU.ActiveCfg = Debug|Any CPU
-		{6AB5E445-9660-454B-BF02-506000EED978}.net40|Any CPU.Build.0 = Debug|Any CPU
-		{6AB5E445-9660-454B-BF02-506000EED978}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{6AB5E445-9660-454B-BF02-506000EED978}.Release|Any CPU.Build.0 = Debug|Any CPU
-		{6AB5E445-9660-454B-BF02-506000EED978}.SandBox|Any CPU.ActiveCfg = Debug|Any CPU
-		{6AB5E445-9660-454B-BF02-506000EED978}.SandBox|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -138,7 +106,6 @@ Global
 		{7EDA8CFE-B576-480B-804E-63DC372CF41D} = {DAF26FA7-FEE5-45D5-81D3-A473B858C7AA}
 		{4832D00A-BE3B-4F3B-93DB-D2FB6406F1B3} = {DAF26FA7-FEE5-45D5-81D3-A473B858C7AA}
 		{A3FCE345-F767-487F-86BF-DFA78B4BC218} = {DAF26FA7-FEE5-45D5-81D3-A473B858C7AA}
-		{6AB5E445-9660-454B-BF02-506000EED978} = {D99D7B57-1FA8-43F4-99D5-DA37D316F960}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0295A474-5FDB-4E74-89E4-048C0F088903}

--- a/MarkdownMonster/_Classes/MarkdownDocument.cs
+++ b/MarkdownMonster/_Classes/MarkdownDocument.cs
@@ -807,15 +807,24 @@ namespace MarkdownMonster
                 mmApp.Configuration.RenderTheme = "Dharkan";
                 themeHtml = "<html><body><h3>Invalid Theme or missing files. Resetting to Dharkan.</h3></body></html>";
             }
-            var html = themeHtml.Replace("{$themePath}", "file:///" + themePath)
-                .Replace("{$docPath}", "file:///" + docPath)
-                .Replace("{$markdownHtml}", markdownHtml);
+            //var html = themeHtml.Replace("{$themePath}", "file:///" + themePath)
+            //    .Replace("{$docPath}", "file:///" + docPath)
+            //    .Replace("{$markdownHtml}", markdownHtml);
+            var html = UpdateThemeHtml( themeHtml, themePath, docPath, markdownHtml );
 
-            if (!WriteFile(filename, html))
+            if( !WriteFile(filename, html))
                 return null;
 
             return html;
         }
+
+        public static Func<string, string, string, string, string> UpdateThemeHtml = ( themeHtml, themePath, docPath, markdownHtml ) => {
+            var html = themeHtml.Replace( "{$themePath}", "file:///" + themePath )
+                .Replace( "{$docPath}", "file:///" + docPath )
+                .Replace( "{$markdownHtml}", markdownHtml );
+            return html;
+        };
+
         #endregion
 
         #region INotifyPropertyChanged

--- a/MarkdownMonster/_Classes/MarkdownParser/MarkdownParserMarkDig.cs
+++ b/MarkdownMonster/_Classes/MarkdownParser/MarkdownParserMarkDig.cs
@@ -45,16 +45,16 @@ namespace MarkdownMonster
     /// Wrapper around the CommonMark.NET parser that provides a cached
     /// instance of the Markdown parser. Hooks up custom processing.
     /// </summary>
-    public class  MarkdownParserMarkdig : MarkdownParserBase
+    public class MarkdownParserMarkdig : MarkdownParserBase
     {
         public static MarkdownPipeline Pipeline;
 
         private readonly bool _usePragmaLines;
 
-        public MarkdownParserMarkdig(bool usePragmaLines = false, bool force = false)
+        public MarkdownParserMarkdig( bool usePragmaLines = false, bool force = false )
         {
             _usePragmaLines = usePragmaLines;
-            if (force || Pipeline == null)
+            if( force || Pipeline == null )
             {
                 var builder = CreatePipelineBuilder();
                 Pipeline = builder.Build();
@@ -66,77 +66,96 @@ namespace MarkdownMonster
         /// </summary>
         /// <param name="markdown"></param>
         /// <returns></returns>        
-        public override string Parse(string markdown)
+        public override string Parse( string markdown )
         {
-            if (string.IsNullOrEmpty(markdown))
+            if( string.IsNullOrEmpty( markdown ) )
                 return string.Empty;
 
             var htmlWriter = new StringWriter();
-            var renderer = CreateRenderer(htmlWriter);
+            var renderer = CreateRenderer( htmlWriter );
 
-            Markdown.Convert(markdown, renderer, Pipeline);
+            Markdown.Convert( markdown, renderer, Pipeline );
             var html = htmlWriter.ToString();
-            
-            html = ParseFontAwesomeIcons(html);
 
-            if (mmApp.Configuration.MarkdownOptions.RenderLinksAsExternal)
-                html = ParseExternalLinks(html);
+            html = ParseFontAwesomeIcons( html );
 
-            if (!mmApp.Configuration.MarkdownOptions.AllowRenderScriptTags)
-                html = ParseScript(html);  
-                      
+            if( mmApp.Configuration.MarkdownOptions.RenderLinksAsExternal )
+                html = ParseExternalLinks( html );
+
+            if( !mmApp.Configuration.MarkdownOptions.AllowRenderScriptTags )
+                html = ParseScript( html );
+
             return html;
         }
 
-        protected virtual MarkdownPipelineBuilder CreatePipelineBuilder()
+        protected virtual MarkdownPipelineBuilder BuildPipeline( MarkdownOptionsConfiguration options, MarkdownPipelineBuilder builder )
         {
-            var builder = new MarkdownPipelineBuilder();
-
-            var options = mmApp.Configuration.MarkdownOptions;
-            if (options.AutoLinks)
+            //var options = mmApp.Configuration.MarkdownOptions;
+            if( options.AutoLinks )
                 builder = builder.UseAutoLinks();
-            if (options.AutoHeaderIdentifiers)
+            if( options.AutoHeaderIdentifiers )
                 builder = builder.UseAutoIdentifiers();
-            if (options.Abbreviations)
+            if( options.Abbreviations )
                 builder = builder.UseAbbreviations();
 
-            if (options.StripYamlFrontMatter)
+            if( options.StripYamlFrontMatter )
                 builder = builder.UseYamlFrontMatter();
-            if (options.EmojiAndSmiley)
+            if( options.EmojiAndSmiley )
                 builder = builder.UseEmojiAndSmiley();
-            if (options.MediaLinks)
+            if( options.MediaLinks )
                 builder = builder.UseMediaLinks();
-            if (options.ListExtras)
+            if( options.ListExtras )
                 builder = builder.UseListExtras();
-            if (options.Figures)
+            if( options.Figures )
                 builder = builder.UseFigures();
-            if (options.GithubTaskLists)
+            if( options.GithubTaskLists )
                 builder = builder.UseTaskLists();
-            if (options.SmartyPants)
-                builder = builder.UseSmartyPants();            
+            if( options.SmartyPants )
+                builder = builder.UseSmartyPants();
 
-            if (_usePragmaLines)
+            if( _usePragmaLines )
                 builder = builder.UsePragmaLines();
 
             try
             {
-                if (!string.IsNullOrWhiteSpace(options.MarkdigExtensions))
+                if( !string.IsNullOrWhiteSpace( options.MarkdigExtensions ) )
                 {
-                    builder = builder.Configure(options.MarkdigExtensions.Replace(",","+"));
+                    builder = builder.Configure( options.MarkdigExtensions.Replace( ",", "+" ) );
                 }
             }
-            catch(ArgumentException ex)
+            catch( ArgumentException ex )
             {
                 // One or more of the extension options is invalid. 
-                mmApp.Log("Failed to load Markdig extensions: " + options.MarkdigExtensions + "\r\n" + ex.Message,ex);
+                mmApp.Log( "Failed to load Markdig extensions: " + options.MarkdigExtensions + "\r\n" + ex.Message, ex );
             }
 
             return builder;
         }
 
-        protected virtual IMarkdownRenderer CreateRenderer(TextWriter writer)
+        protected virtual MarkdownPipelineBuilder CreatePipelineBuilder()
         {
-            return new HtmlRenderer(writer);
+            // ******
+            var options = mmApp.Configuration.MarkdownOptions;
+            var builder = new MarkdownPipelineBuilder();
+
+            // ******
+            try
+            {
+                builder = BuildPipeline( options, builder );
+            }
+            catch( ArgumentException ex )
+            {
+                mmApp.Log( $"Failed to build pipeline: {ex.Message}", ex );
+            }
+
+            // ******
+            return builder;
+        }
+
+
+        protected virtual IMarkdownRenderer CreateRenderer( TextWriter writer )
+        {
+            return new HtmlRenderer( writer );
         }
     }
 }


### PR DESCRIPTION
I know I should only submit one change at a time but these are pretty straight forward.

Changes to MarkdownParserMarkDig.cs to make it easier to derive from; allow derived class to call up to do basic pipeline initialization.

Changes to MarkdownDocument.cs to allow addins to participate in the processing of the theme files; added a Func<> that is called by RenderHtmlToFile(). External code can hook this by replacing the Func<>.

Note: was only able to compile Markdown Monster itself because of errors, missing Westwind.Utilities among others. so I had to unload the other projects and the website. This is why there are changes to the .sln file.

commit:
… moving the actual configuration of the markdig pipeline into its own method. modified MarkdownDocument.RenderHtmlToFile() to call a  Func<> to replace the chunks of the theme file, allow processing to be overriden.