### PR TITLE
Mods to allow plugins to examine and modify the preview.

### DIFF
--- a/MarkdownMonster/_Classes/AddInInterfaces/AddinManager.cs
+++ b/MarkdownMonster/_Classes/AddInInterfaces/AddinManager.cs
@@ -307,13 +307,13 @@ namespace MarkdownMonster.AddIns
         /// A string.
         /// </returns>
 
-        public string RaiseOnUpdateTheme( string html, string markdownHtml )
+        public string RaiseAfterRenderPreview( string html, string markdownHtml )
         {
             foreach( var addin in AddIns )
             {
                 try
                 {
-                    html = addin?.UpdateTheme?.Invoke( html, markdownHtml ) ?? html;
+                    html = addin?.AfterRenderPreview?.Invoke( html, markdownHtml ) ?? html;
                 }
                 catch( Exception ex )
                 {

--- a/MarkdownMonster/_Classes/AddInInterfaces/AddinManager.cs
+++ b/MarkdownMonster/_Classes/AddInInterfaces/AddinManager.cs
@@ -286,10 +286,45 @@ namespace MarkdownMonster.AddIns
             }
         }
 
-        
+
 
 
         #region Raise Events
+
+        /////////////////////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Raises the update theme event.
+        /// </summary>
+        ///
+        /// <param name="html">
+        /// The HTML.
+        /// </param>
+        /// <param name="markdownHtml">
+        /// The markdown HTML.
+        /// </param>
+        ///
+        /// <returns>
+        /// A string.
+        /// </returns>
+
+        public string RaiseOnUpdateTheme( string html, string markdownHtml )
+        {
+            foreach( var addin in AddIns )
+            {
+                try
+                {
+                    html = addin?.UpdateTheme?.Invoke( html, markdownHtml ) ?? html;
+                }
+                catch( Exception ex )
+                {
+                    mmApp.Log( addin.Id + "::AddIn::OnUpdateTheme Error: " + ex.GetBaseException().Message );
+                }
+            }
+
+            return html;
+        }
+
+
         public void RaiseOnApplicationStart()
         {
             foreach (var addin in AddIns)

--- a/MarkdownMonster/_Classes/AddInInterfaces/AddinManager.cs
+++ b/MarkdownMonster/_Classes/AddInInterfaces/AddinManager.cs
@@ -307,17 +307,17 @@ namespace MarkdownMonster.AddIns
         /// A string.
         /// </returns>
 
-        public string RaiseAfterRenderPreview( string html, string markdownHtml )
+        public string RaiseModifyPreviewHtml( string html, string markdownHtml )
         {
             foreach( var addin in AddIns )
             {
                 try
                 {
-                    html = addin?.AfterRenderPreview?.Invoke( html, markdownHtml ) ?? html;
+                    html = addin?.ModifyPreviewHtml?.Invoke( html, markdownHtml ) ?? html;
                 }
                 catch( Exception ex )
                 {
-                    mmApp.Log( addin.Id + "::AddIn::OnUpdateTheme Error: " + ex.GetBaseException().Message );
+                    mmApp.Log( addin.Id + "::AddIn::ModifyPreviewHtml Error: " + ex.GetBaseException().Message );
                 }
             }
 

--- a/MarkdownMonster/_Classes/AddInInterfaces/MarkdownMonsterAddin.cs
+++ b/MarkdownMonster/_Classes/AddInInterfaces/MarkdownMonsterAddin.cs
@@ -108,7 +108,7 @@ namespace MarkdownMonster.AddIns
         /// delegate string AfterRenderPreviewDelegate( string themeHtml, string  markdownHtml );
         /// </summary>
 
-        public Func<string, string, string> AfterRenderPreview = null;
+        public Func<string, string, string> ModifyPreviewHtml = null;
 
         /// <summary>
         /// Called when the Menu or Toolbar button is clicked

--- a/MarkdownMonster/_Classes/AddInInterfaces/MarkdownMonsterAddin.cs
+++ b/MarkdownMonster/_Classes/AddInInterfaces/MarkdownMonsterAddin.cs
@@ -91,6 +91,24 @@ namespace MarkdownMonster.AddIns
 
         #region Event Handlers
 
+        /////////////////////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Allows plugings to intercept the html used for the preview, to
+        /// examine or further manipulate it, e.g. insert a style
+        /// block in the head.
+        /// 
+        /// Why a Func&lt;&gt; rather than a virtual method? A matter of
+        /// coding style; rather than override a method and forward the
+        /// arguments to some other code, the plugin can just set the
+        /// UpdateTheme member to where ever the theme html needs to be
+        /// looked at. A virtual method would work too.
+        /// 
+        /// If this were a delegate it's signature would be:
+        /// 
+        /// delegate string UpdateThemeDelegate( string themeHtml, string  markdownHtml );
+        /// </summary>
+
+        public Func<string, string, string> UpdateTheme = null;
 
         /// <summary>
         /// Called when the Menu or Toolbar button is clicked

--- a/MarkdownMonster/_Classes/AddInInterfaces/MarkdownMonsterAddin.cs
+++ b/MarkdownMonster/_Classes/AddInInterfaces/MarkdownMonsterAddin.cs
@@ -105,10 +105,10 @@ namespace MarkdownMonster.AddIns
         /// 
         /// If this were a delegate it's signature would be:
         /// 
-        /// delegate string UpdateThemeDelegate( string themeHtml, string  markdownHtml );
+        /// delegate string AfterRenderPreviewDelegate( string themeHtml, string  markdownHtml );
         /// </summary>
 
-        public Func<string, string, string> UpdateTheme = null;
+        public Func<string, string, string> AfterRenderPreview = null;
 
         /// <summary>
         /// Called when the Menu or Toolbar button is clicked

--- a/MarkdownMonster/_Classes/MarkdownDocument.cs
+++ b/MarkdownMonster/_Classes/MarkdownDocument.cs
@@ -47,6 +47,8 @@ using System.Security;
 
 namespace MarkdownMonster
 {
+    using AddIns;
+
     /// <summary>
     /// Class that wraps the Active Markdown document used in the
     /// editor.
@@ -811,7 +813,9 @@ namespace MarkdownMonster
                 .Replace("{$docPath}", "file:///" + docPath)
                 .Replace("{$markdownHtml}", markdownHtml);
 
-            if (!WriteFile(filename, html))
+            html = AddinManager.Current.RaiseOnUpdateTheme( html, markdownHtml );
+
+            if( !WriteFile(filename, html))
                 return null;
 
             return html;

--- a/MarkdownMonster/_Classes/MarkdownDocument.cs
+++ b/MarkdownMonster/_Classes/MarkdownDocument.cs
@@ -813,7 +813,7 @@ namespace MarkdownMonster
                 .Replace("{$docPath}", "file:///" + docPath)
                 .Replace("{$markdownHtml}", markdownHtml);
 
-            html = AddinManager.Current.RaiseOnUpdateTheme( html, markdownHtml );
+            html = AddinManager.Current.RaiseAfterRenderPreview( html, markdownHtml );
 
             if( !WriteFile(filename, html))
                 return null;

--- a/MarkdownMonster/_Classes/MarkdownDocument.cs
+++ b/MarkdownMonster/_Classes/MarkdownDocument.cs
@@ -813,7 +813,7 @@ namespace MarkdownMonster
                 .Replace("{$docPath}", "file:///" + docPath)
                 .Replace("{$markdownHtml}", markdownHtml);
 
-            html = AddinManager.Current.RaiseAfterRenderPreview( html, markdownHtml );
+            html = AddinManager.Current.RaiseModifyPreviewHtml( html, markdownHtml );
 
             if( !WriteFile(filename, html))
                 return null;


### PR DESCRIPTION

I am working on a plugin that puts a preprocessor between the editor and the markdown processor. I would like to be able to examine the html produced by markdig and the themed output, possibly modify it. The changes I've made to MM can be seen in the diff, I've also included them below to give you a quick overview.

This is a lot more code than when I tried the same general idea in a previous pull request, a small static Func&lt;&gt; :-)

Thanks,

Joe McLain

```
***************** MarkdownDocument.cs 

namespace MarkdownMonster
{
  using AddIns;



          html = AddinManager.Current.RaiseOnUpdateTheme( html );
```

```
***************** AddinManager.cs


        #region Raise Events

       /////////////////////////////////////////////////////////////////////////////
       /// <summary>
       /// Raises the update theme event.
       /// </summary>
       ///
       /// <param name="html">
       /// The HTML.
       /// </param>
       /// <param name="markdownHtml">
       /// The markdown HTML.
       /// </param>
       ///
       /// <returns>
       /// A string.
       /// </returns>

       public string RaiseOnUpdateTheme( string html, string markdownHtml )
       {
           foreach( var addin in AddIns )
           {
               try
               {
                   html = addin?.UpdateTheme?.Invoke( html, markdownHtml ) ?? html;
               }
               catch( Exception ex )
               {
                   mmApp.Log( addin.Id + "::AddIn::OnUpdateTheme Error: " + ex.GetBaseException().Message );
               }
           }

           return html;
       }
```

```
***************** MarkdownMonsterAddins.cs

        #region Event Handlers

      /////////////////////////////////////////////////////////////////////////////
      /// <summary>
      /// Allows plugings to intercept the html used for the preview, to
      /// examine or further manipulate it, e.g. insert a style
      /// block in the head.
      /// 
      /// Why a Func&lt;&gt; rather than a virtual method? A matter of
      /// coding style; rather than override a method and forward the
      /// arguments to some other code, the plugin can just set the
      /// UpdateTheme member to where ever the theme html needs to be
      /// looked at. A virtual method would work too.
      /// 
      /// If this were a delegate it's signature would be:
      /// 
      /// delegate string UpdateThemeDelegate( string themeHtml, string  markdownHtml );
      /// </summary>

      public Func<string, string, string> UpdateTheme = null;
```