### PR TITLE
Option to show invisible characters

### DIFF
--- a/MarkdownMonster/Editor/editor.js
+++ b/MarkdownMonster/Editor/editor.js
@@ -46,6 +46,7 @@ var te = window.textEditor = {
         editor.setReadOnly(false);
         editor.setHighlightActiveLine(editorSettings.highlightActiveLine);
         editor.setShowPrintMargin(editorSettings.showPrintMargin);
+        editor.setShowInvisibles(editorSettings.showInvisibles);
 
         //te.settheme(editorSettings.theme, editorSettings.fontSize, editorSettings.wrapText);
         editor.setTheme("ace/theme/" + editorSettings.theme);
@@ -499,6 +500,9 @@ var te = window.textEditor = {
     },
     setShowLineNumbers: function(showLineNumbers) { 
         te.editor.renderer.setShowGutter(showLineNumbers);  
+    },
+    setShowInvisibles: function (showInvisibles) { 
+        te.editor.renderer.setShowInvisibles(showInvisibles);  
     },
     setWordWrap: function (enable) {
         te.editor.session.setUseWrapMode(enable);

--- a/MarkdownMonster/Editor/editorSettings.js
+++ b/MarkdownMonster/Editor/editorSettings.js
@@ -9,5 +9,6 @@ var editorSettings = {
   "showPrintMargin": false,
   "tabSpaces": 4,
   "theme": "twilight",
-  "wrapText": true  
+  "wrapText": true,
+  "showInvisibles": false
 };

--- a/MarkdownMonster/MainWindow.xaml
+++ b/MarkdownMonster/MainWindow.xaml
@@ -321,8 +321,13 @@
                           Header="Line _Numbers"                         
                           Click="Button_Handler"
                           IsCheckable="True"
-                          IsChecked="{Binding Configuration.EditorShowLineNumbers}"
-                />
+                          IsChecked="{Binding Configuration.EditorShowLineNumbers}" />
+
+                <MenuItem Name="ButtonShowInvisibles" 
+                          Header="Show Invisible Characters"
+                          Click="Button_Handler"
+                          IsCheckable="True"
+                          IsChecked="{Binding Configuration.EditorShowInvisibles}" />
             </MenuItem>
             <MenuItem Header="_Help">
                 <MenuItem Name="MenuDocumentation" Header="Documentation" Command="{Binding HelpCommand}" InputGestureText="F1" />

--- a/MarkdownMonster/MainWindow.xaml.cs
+++ b/MarkdownMonster/MainWindow.xaml.cs
@@ -1467,7 +1467,12 @@ namespace MarkdownMonster
 			    Model.ActiveEditor?.SetWordWrap(Model.Configuration.EditorWrapText);
 			}
             else if (button == ButtonLineNumbers)
-			{   Model.ActiveEditor?.SetShowLineNumbers(Model.Configuration.EditorShowLineNumbers);
+			{
+			    Model.ActiveEditor?.SetShowLineNumbers(Model.Configuration.EditorShowLineNumbers);
+			}
+            else if (button == ButtonShowInvisibles)
+			{
+			    Model.ActiveEditor?.SetShowInvisibles(Model.Configuration.EditorShowInvisibles);
 			}
             else if (button == ButtonStatusEncrypted)
 			{

--- a/MarkdownMonster/_Classes/Configuration/ApplicationConfiguration.cs
+++ b/MarkdownMonster/_Classes/Configuration/ApplicationConfiguration.cs
@@ -264,6 +264,21 @@ namespace MarkdownMonster
         }
         private bool _EditorShowLineNumbers = false;
 
+        /// <summary>
+        /// Determines whether the editor should show invisible characters.
+        /// Default is <see langword="false" />.
+        /// </summary>
+        public bool EditorShowInvisibles
+        {
+            get { return _EditorShowInvisibles; }
+            set
+            {
+                if (_EditorShowInvisibles == value) return;
+                _EditorShowInvisibles = value;
+                OnPropertyChanged(nameof(EditorShowInvisibles));
+            }
+        }
+        private bool _EditorShowInvisibles = false;
 
         /// <summary>
         /// Determines whether the editor wraps text or extends lines

--- a/MarkdownMonster/_Classes/MarkdownDocumentEditor.cs
+++ b/MarkdownMonster/_Classes/MarkdownDocumentEditor.cs
@@ -141,6 +141,7 @@ namespace MarkdownMonster
 					AceEditor?.setlanguage(EditorSyntax);
                 RestyleEditor(true);
                 SetShowLineNumbers(mmApp.Configuration.EditorShowLineNumbers);
+                SetShowInvisibles(mmApp.Configuration.EditorShowInvisibles);
 
 
                 if (InitialLineNumber > 0)
@@ -587,6 +588,20 @@ namespace MarkdownMonster
                 show = mmApp.Configuration.EditorShowLineNumbers;
 
             AceEditor?.setShowLineNumbers(show.Value);
+        }
+
+        /// <summary>
+        /// Sets line number gutter on and off. Separated out from Restyle Editor to 
+        /// allow line number config to be set separately from main editor settings
+        /// for specialty file editing.
+        /// </summary>
+        /// <param name="show"></param>
+        public void SetShowInvisibles(bool? show = null)
+        {
+            if (show == null)
+                show = mmApp.Configuration.EditorShowInvisibles;
+
+            AceEditor?.setShowInvisibles(show.Value);
         }
 
         /// <summary>

--- a/MarkdownMonster/_Classes/MarkdownDocumentEditor.cs
+++ b/MarkdownMonster/_Classes/MarkdownDocumentEditor.cs
@@ -591,9 +591,7 @@ namespace MarkdownMonster
         }
 
         /// <summary>
-        /// Sets line number gutter on and off. Separated out from Restyle Editor to 
-        /// allow line number config to be set separately from main editor settings
-        /// for specialty file editing.
+        /// Enables or disables the display of invisible characters.
         /// </summary>
         /// <param name="show"></param>
         public void SetShowInvisibles(bool? show = null)


### PR DESCRIPTION
This PR adds the option to show invisible characters. It uses the built-in feature of Ace editor, so I only had to add some glue logic.

![markdown-monster-show-invisbles](https://user-images.githubusercontent.com/73690/33485186-ba9f721e-d6a5-11e7-9501-04e89f533599.gif)
