### PR TITLE
Enable ACE scroll past end

### DIFF
--- a/MarkdownMonster/Editor/editor.js
+++ b/MarkdownMonster/Editor/editor.js
@@ -47,6 +47,7 @@ var te = window.textEditor = {
         editor.setHighlightActiveLine(editorSettings.highlightActiveLine);
         editor.setShowPrintMargin(editorSettings.showPrintMargin);
         editor.setShowInvisibles(editorSettings.showInvisibles);
+        editor.setScrollPastEnd(editorSettings.scrollPastEnd);
 
         //te.settheme(editorSettings.theme, editorSettings.fontSize, editorSettings.wrapText);
         editor.setTheme("ace/theme/" + editorSettings.theme);
@@ -544,6 +545,9 @@ var te = window.textEditor = {
     },
     setShowInvisibles: function (showInvisibles) { 
         te.editor.renderer.setShowInvisibles(showInvisibles);  
+    },
+    setScrollPastEnd: function (scrollPastEnd) {
+      te.editor.renderer.setScrollPastEnd(scrollPastEnd);
     },
     setWordWrap: function (enable) {
         te.editor.session.setUseWrapMode(enable);

--- a/MarkdownMonster/Editor/editorSettings.js
+++ b/MarkdownMonster/Editor/editorSettings.js
@@ -10,5 +10,6 @@ var editorSettings = {
   "tabSpaces": 4,
   "theme": "twilight",
   "wrapText": true,
-  "showInvisibles": false
+  "showInvisibles": false,
+  "scrollPastEnd": true
 };

--- a/MarkdownMonster/Editor/scripts/Ace/ace.js
+++ b/MarkdownMonster/Editor/scripts/Ace/ace.js
@@ -4933,6 +4933,7 @@ var BidiHandler = function(session) {
     this.charWidths = [];
     this.EOL = "\xAC";
     this.showInvisibles = true;
+    this.scrollPastEnd = false;
     this.isRtlDir = false;
     this.line = "";
     this.wrapIndent = 0;
@@ -5066,7 +5067,16 @@ var BidiHandler = function(session) {
         this.showInvisibles = showInvisibles;
         this.currentRow = null;
     };
+  
+    this.getScrollPastEnd = function () {
+      return this.scrollPastEnd;
+    };
 
+    this.setScrollPastEnd = function (scrollPastEnd) {
+      this.scrollPastEnd = scrollPastEnd;
+      this.currentRow = null;
+    };
+  
     this.setEolChar = function(eolChar) {
         this.EOL = eolChar; 
     };
@@ -13622,6 +13632,13 @@ Editor.$uid = 0;
         return this.renderer.getShowInvisibles();
     };
 
+    this.setScrollPastEnd = function (scrollPastEnd) {
+      this.renderer.setScrollPastEnd(scrollPastEnd);
+    };
+    this.getScrollPastEnd = function () {
+      return this.renderer.getScrollPastEnd();
+    };
+
     this.setDisplayIndentGuides = function(display) {
         this.renderer.setDisplayIndentGuides(display);
     };
@@ -15307,7 +15324,17 @@ var Text = function(parentEl) {
         this.$computeTabString();
         return true;
     };
+    
+    this.scrollPastEnd = false;
+    this.setScrollPastEnd = function (scrollPastEnd) {
+      if (this.scrollPastEnd == scrollPastEnd)
+        return false;
 
+      this.scrollPastEnd = scrollPastEnd;
+      this.$computeTabString();
+      return true;
+    };
+  
     this.displayIndentGuides = true;
     this.setDisplayIndentGuides = function(display) {
         if (this.displayIndentGuides == display)
@@ -17024,7 +17051,16 @@ var VirtualRenderer = function(container, theme) {
     this.getShowInvisibles = function() {
         return this.getOption("showInvisibles");
     };
-    this.getDisplayIndentGuides = function() {
+  
+    this.setScrollPastEnd = function (scrollPastEnd) {
+      this.setOption("scrollPastEnd", scrollPastEnd);
+      this.session.$bidiHandler.setScrollPastEnd(scrollPastEnd);
+    };
+    this.getScrollPastEnd = function () {
+      return this.getOption("scrollPastEnd");
+    };
+  
+    this.getDisplayIndentGuides = function () {
         return this.getOption("displayIndentGuides");
     };
 

--- a/MarkdownMonster/MainWindow.xaml
+++ b/MarkdownMonster/MainWindow.xaml
@@ -351,6 +351,12 @@
                           Click="Button_Handler"
                           IsCheckable="True"
                           IsChecked="{Binding Configuration.EditorShowInvisibles}" />
+                
+                <MenuItem Name="ButtonScrollPastEnd"
+                          Header="Mouse Wheel Scroll Past End"
+                          Click="Button_Handler"
+                          IsCheckable="True"
+                          IsChecked="{Binding Configuration.EditorScrollPastEnd}" />
             </MenuItem>
 
             <!-- generated dynamically by command -->

--- a/MarkdownMonster/MainWindow.xaml.cs
+++ b/MarkdownMonster/MainWindow.xaml.cs
@@ -1625,6 +1625,10 @@ namespace MarkdownMonster
 			{
 			    Model.ActiveEditor?.SetShowInvisibles(Model.Configuration.EditorShowInvisibles);
 			}
+            else if (button == ButtonScrollPastEnd)
+            {
+                Model.ActiveEditor?.SetScrollPastEnd(Model.Configuration.EditorScrollPastEnd);
+            }
             else if (button == ButtonStatusEncrypted)
 			{
 			    var dialog = new FilePasswordDialog(Model.ActiveDocument,false)

--- a/MarkdownMonster/_Classes/Configuration/ApplicationConfiguration.cs
+++ b/MarkdownMonster/_Classes/Configuration/ApplicationConfiguration.cs
@@ -297,6 +297,23 @@ namespace MarkdownMonster
         private bool _EditorShowInvisibles = false;
 
         /// <summary>
+        /// Determines whether the edittor should scroll past the last line using the mouse wheel.
+        /// Default is <see langword="false"/>
+        /// </summary>
+        public bool EditorScrollPastEnd
+        {
+            get { return _EditorScrollPastEnd; }
+            set
+            {
+                if (_EditorScrollPastEnd == value) return;
+                _EditorScrollPastEnd = value;
+                OnPropertyChanged(nameof(EditorScrollPastEnd));
+            }
+        }
+
+        private bool _EditorScrollPastEnd = false;
+
+        /// <summary>
         /// Determines whether the editor wraps text or extends lines
         /// out. Default is false.
         /// </summary>

--- a/MarkdownMonster/_Classes/MarkdownDocumentEditor.cs
+++ b/MarkdownMonster/_Classes/MarkdownDocumentEditor.cs
@@ -151,7 +151,7 @@ namespace MarkdownMonster
                 RestyleEditor(true);
                 SetShowLineNumbers(mmApp.Configuration.EditorShowLineNumbers);
                 SetShowInvisibles(mmApp.Configuration.EditorShowInvisibles);
-
+                SetScrollPastEnd(mmApp.Configuration.EditorScrollPastEnd);
 
                 if (InitialLineNumber > 0)
                 {
@@ -823,6 +823,15 @@ namespace MarkdownMonster
                 show = mmApp.Configuration.EditorShowInvisibles;
 
             AceEditor?.setShowInvisibles(show.Value);
+        }
+
+
+        public void SetScrollPastEnd(bool? scroll = null)
+        {
+            if (scroll == null)
+                scroll = mmApp.Configuration.EditorScrollPastEnd;
+
+            AceEditor?.setScrollPastEnd(scroll.Value);
         }
 
         /// <summary>


### PR DESCRIPTION
This change enables the ACE editor's scrollPastEnd setting. In practice, one can only use the mouse wheel to scroll past the last line. I confirmed this on the [ACE Kitchen Sink](https://ace.c9.io/kitchen-sink.html). That's unfortunate; I wish the ACE behavior was to add scroll bar padding as MS Word and Notepad++ do.

For that reason, I named the menu item "Mouse wheel scroll past end." The feature seems to work as expected, and is a common editor behavior. I found myself missing it in MM.

I have two outstanding concerns/questions:

1. Will the property initially be set to false, as intended?
2. Are there tests I should write? I didn't find comparable tests, but may not have known what to look for.

Thanks!
