### PR TITLE
Fix for the window sub-menu mnemonics

### DIFF
--- a/MarkdownMonster/AppModel.cs
+++ b/MarkdownMonster/AppModel.cs
@@ -93,15 +93,6 @@ namespace MarkdownMonster
                 OnPropertyChanged(nameof(ActiveEditor));                
                 OnPropertyChanged(nameof(IsEditorActive));                
 
-                Dispatcher.CurrentDispatcher.InvokeAsync(() =>
-                {
-                    Commands.InvalidateCommands();
-
-                    //CommandManager.InvalidateRequerySuggested();
-                    //SaveCommand.InvalidateCanExecute();
-                    //SaveAsHtmlCommand.InvalidateCanExecute();
-                },DispatcherPriority.ApplicationIdle);
-
                 Window.ToolbarEdit.IsEnabled = IsEditorActive;
             }
         }

--- a/MarkdownMonster/Controls/CommandBase.cs
+++ b/MarkdownMonster/Controls/CommandBase.cs
@@ -9,13 +9,12 @@ namespace MarkdownMonster
     public class CommandBase : ICommand
     {
         private readonly Action<object, ICommand> _execute;
-        private readonly Func<object, ICommand,bool> _canExecute;
+        private readonly Func<object, ICommand, bool> _canExecute;
         private readonly Func<object, ICommand, bool> _previewExecute;
 
         public string Caption { get; set; }
 
-        public string ToolTip { get; set; }   
-
+        public string ToolTip { get; set; }
 
         /// <summary>
         /// Constructor that allows you to hook up each of the command events
@@ -28,38 +27,28 @@ namespace MarkdownMonster
             _execute = execute;
             _canExecute = canExecute;
             _previewExecute = previewExecute;
-
         }
 
         public bool CanExecute(object parameter)
         {
-            if (_canExecute != null)
-                return  _canExecute.Invoke(parameter, this);
-
-            return true;
+            return _canExecute == null || _canExecute.Invoke(parameter, this);
         }
-
 
         public bool PreviewExecute(object parameter)
         {
-            if (_previewExecute != null)
-                return _previewExecute.Invoke(parameter,this);
-
-            return true;
+            return _previewExecute == null || _previewExecute.Invoke(parameter, this);
         }
 
         public void Execute(object parameter)
         {
             if (PreviewExecute(parameter) && CanExecute(parameter))
                 _execute?.Invoke(parameter, this);
-        }    
-        
-
-        public void InvalidateCanExecute()
-        {
-            CanExecuteChanged?.Invoke(this, new EventArgs());
         }
 
-        public event EventHandler CanExecuteChanged;
+        public event EventHandler CanExecuteChanged
+        {
+            add => CommandManager.RequerySuggested += value;
+            remove => CommandManager.RequerySuggested -= value;
+        }
     }
 }

--- a/MarkdownMonster/MainWindow.xaml.cs
+++ b/MarkdownMonster/MainWindow.xaml.cs
@@ -876,14 +876,6 @@ namespace MarkdownMonster
                     }
                 }
 
-                doc.PropertyChanged += (sender, e) =>
-                {
-                    if (e.PropertyName == "IsDirty")
-                    {
-                        //CommandManager.InvalidateRequerySuggested();
-                        Model.Commands.SaveCommand.InvalidateCanExecute();
-                    }
-                };
                 editor.MarkdownDocument = doc;
                 SetTabHeaderBinding(tab, doc, "FilenameWithIndicator");
                 tab.ToolTip = doc.Filename;
@@ -1116,9 +1108,6 @@ namespace MarkdownMonster
             }
 
             batchTabAction = false;
-
-            //WindowUtilities.InvalidateMenuCommands(MainMenu);
-            Model.Commands.InvalidateCommands();
 
             return true;
         }

--- a/MarkdownMonster/_Classes/AddInInterfaces/AddinManager.cs
+++ b/MarkdownMonster/_Classes/AddInInterfaces/AddinManager.cs
@@ -244,23 +244,6 @@ namespace MarkdownMonster.AddIns
 
                                 addin.Model.Window.ToolbarAddIns.Items.Add(tcitem);
                             };
-
-                            addin.Model.PropertyChanged += (s, arg) =>
-                            {
-                                if (arg.PropertyName == "ActiveDocument" || arg.PropertyName == "ActiveEditor")
-                                {
-                                    addInMenuItem.Command?.InvalidateCanExecute();
-
-                                    // this shouldn't be necessary but it looks if the Command bindings work correctly
-                                    //var item = addin.Model.Window.ToolbarAddIns.Items[toolIndex] as Button;
-                                    //if (item != null)
-                                    //{
-                                    //    ((CommandBase)item.Command).InvalidateCanExecute();
-                                    //    if (menuItem.CanExecute != null)
-                                    //        item.IsEnabled = menuItem.CanExecute.Invoke(null);
-                                    //}
-                                }
-                            };                        
                         }
                     }
                     catch (Exception ex)

--- a/MarkdownMonster/_Classes/AppCommands.cs
+++ b/MarkdownMonster/_Classes/AppCommands.cs
@@ -821,6 +821,8 @@ Do you want to View in Browser now?
                 }
 
                 mi.IsSubmenuOpen = true;
+                // focus the menu to enable the mnemonics for the dynamically created submenus
+                mi.Focus();
 
                 mi.SubmenuClosed += (s,e) => ((MenuItem)s).Items.Clear();
             }, (p, c) => true);

--- a/MarkdownMonster/_Classes/AppCommands.cs
+++ b/MarkdownMonster/_Classes/AppCommands.cs
@@ -90,25 +90,6 @@ namespace MarkdownMonster
             ShowFolderBrowser();
         }
 
-
-        private List<PropertyInfo> commandProperties;
-
-        public void InvalidateCommands()
-        {
-            if (commandProperties == null)
-            {
-                commandProperties = typeof(AppCommands)
-                    .GetProperties(BindingFlags.Public |
-                                   BindingFlags.Instance |
-                                   BindingFlags.GetProperty)
-                    .Where(t => t.PropertyType == typeof(CommandBase))
-                    .ToList();
-            }
-
-            foreach (var pi in commandProperties)
-                (pi.GetValue(this) as CommandBase)?.InvalidateCanExecute();
-        }
-
         #region Files And File Management
 
         public CommandBase NewDocumentCommand { get; set; }

--- a/MarkdownMonster/_Classes/Configuration/ApplicationConfiguration.cs
+++ b/MarkdownMonster/_Classes/Configuration/ApplicationConfiguration.cs
@@ -643,14 +643,22 @@ namespace MarkdownMonster
 
             // TODO: Remove in future version - added in 1.11
             // fix up new dictionary files
-            if (Editor.Dictionary == "en_US")
-                Editor.Dictionary = "en-US";
-            else if (Editor.Dictionary == "de_DE")
-                Editor.Dictionary = "de";
-            else if (Editor.Dictionary == "fr_FR")
-                Editor.Dictionary = "fr";
-            else if (Editor.Dictionary == "es_ES")
-                Editor.Dictionary = "es";
+            var dict = Editor.Dictionary.ToLower();
+            switch (dict)
+            {
+                case "en_us":
+                    Editor.Dictionary = "en-US";
+                    break;
+                case "de_de":
+                    Editor.Dictionary = "de";
+                    break;
+                case "fr_fr":
+                    Editor.Dictionary = "fr";
+                    break;
+                case "es_es":
+                    Editor.Dictionary = "es";
+                    break;
+            }
         }
 
         public void AddRecentFile(string filename)

--- a/Tests/MarkdownMonster.Test/MarkdownMonster.Test.csproj
+++ b/Tests/MarkdownMonster.Test/MarkdownMonster.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\LibGit2Sharp.NativeBinaries.1.0.205\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\..\packages\LibGit2Sharp.NativeBinaries.1.0.205\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -126,7 +126,9 @@
     <None Include="SupportFiles\SampleMarkdown.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\MarkdownMonster\MarkdownMonster.csproj">
@@ -163,7 +165,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\LibGit2Sharp.NativeBinaries.1.0.205\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\LibGit2Sharp.NativeBinaries.1.0.205\build\LibGit2Sharp.NativeBinaries.props'))" />
+    <Error Condition="!Exists('..\..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
This PR will fix the [SO](https://stackoverflow.com/questions/50431171/wpf-how-to-get-dynamically-added-menu-item-mnemonics-to-work) question and issue.

The sub menus of the window menu shows their mnemonics but it will not execute the commands behind. This is happen caused by the dynamically creation of the sub menus.

So it's necessary to focus the menu again to enable the mnemonics of the sub menus.

I also fixed the CommandBase and use the CommandManager.RequerySuggested on the CanExecuteChanged event, so it's not necessary to invalidate all the stuff per hand.

```
        public event EventHandler CanExecuteChanged
        {
            add => CommandManager.RequerySuggested += value;
            remove => CommandManager.RequerySuggested -= value;
        }
```
