### PR TITLE
Fix build of WeblogAddin.Test

### DIFF
--- a/Tests/WeblogAddin.Test/WeblogAddin.Test.csproj
+++ b/Tests/WeblogAddin.Test/WeblogAddin.Test.csproj
@@ -71,8 +71,8 @@
       <HintPath>..\..\packages\Westwind.Utilities.3.0.24\lib\net46\Westwind.Utilities.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="YamlDotNet, Version=4.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\YamlDotNet.4.2.3\lib\net35\YamlDotNet.dll</HintPath>
+    <Reference Include="YamlDotNet, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\YamlDotNet.5.2.1\lib\net35\YamlDotNet.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>


### PR DESCRIPTION
Fix YamlDotNet dll reference as in the \AddIns\WebLogAddin\WebLogAddin.csproj
as the project didn't build otherwise.