### PR TITLE
Minor image handling fixes

### DIFF
--- a/AddIns/ScreenCaptureAddin/SnagItAutomation.cs
+++ b/AddIns/ScreenCaptureAddin/SnagItAutomation.cs
@@ -489,12 +489,14 @@ namespace SnagItAddin
         {
             if (ex == null)
                 ErrorMessage = string.Empty;
+            else
+            {
+                Exception e = ex;
+                if (checkInner)
+                    e = e.GetBaseException();
 
-            Exception e = ex;
-            if (checkInner)
-                e = e.GetBaseException();
-
-            ErrorMessage = e.Message;
+                ErrorMessage = e.Message;
+            }
         }
 
     }

--- a/AddIns/WebLogAddin/LocalJekyll/LocalJekyllPublisher.cs
+++ b/AddIns/WebLogAddin/LocalJekyll/LocalJekyllPublisher.cs
@@ -580,12 +580,14 @@ namespace WebLogAddin.LocalJekyll
         {
             if (ex == null)
                 ErrorMessage = string.Empty;
+            else
+            {
+                Exception e = ex;
+                if (checkInner)
+                    e = e.GetBaseException();
 
-            Exception e = ex;
-            if (checkInner)
-                e = e.GetBaseException();
-
-            ErrorMessage = e.Message;
+                ErrorMessage = e.Message;
+            }
         }
         #endregion
     }

--- a/AddIns/WebLogAddin/MetaWebLogApi/helpers/FileSystemHelper.cs
+++ b/AddIns/WebLogAddin/MetaWebLogApi/helpers/FileSystemHelper.cs
@@ -16,10 +16,12 @@ namespace WebLogAddin.MetaWebLogApi.helpers
         /// <returns></returns>
         public static byte[] GetFileBytes(string pathToFile)
         {
-            var fs = new FileStream(pathToFile, FileMode.Open, FileAccess.Read);
-            byte[] filebytes = new byte[fs.Length];
-            fs.Read(filebytes, 0, Convert.ToInt32(fs.Length));
-            return filebytes;
+            using (var fs = new FileStream(pathToFile, FileMode.Open, FileAccess.Read))
+            {
+                byte[] filebytes = new byte[fs.Length];
+                fs.Read(filebytes, 0, Convert.ToInt32(fs.Length));
+                return filebytes;
+            }
         }
     }
 }

--- a/MarkdownMonster/Controls/ContextMenus/EditorContextMenu.cs
+++ b/MarkdownMonster/Controls/ContextMenus/EditorContextMenu.cs
@@ -573,8 +573,10 @@ namespace MarkdownMonster.Controls.ContextMenus
 
                                 try
                                 {
-                                    var wc = new WebClient();
-                                    await wc.DownloadFileTaskAsync(new Uri(imageLink), sd.FileName);
+                                    using (var wc = new WebClient())
+                                    {
+                                        await wc.DownloadFileTaskAsync(new Uri(imageLink), sd.FileName);
+                                    }
 
                                     string filename;
                                     if (doc.Filename.Equals("untitled", StringComparison.OrdinalIgnoreCase))

--- a/MarkdownMonster/Windows/ConfigurationEditor/ConfigurationParser.cs
+++ b/MarkdownMonster/Windows/ConfigurationEditor/ConfigurationParser.cs
@@ -109,12 +109,14 @@ namespace MarkdownMonster.Windows.ConfigurationEditor
         {
             if (ex == null)
                 ErrorMessage = string.Empty;
+            else
+            {
+                Exception e = ex;
+                if (checkInner)
+                    e = e.GetBaseException();
 
-            Exception e = ex;
-            if (checkInner)
-                e = e.GetBaseException();
-
-            ErrorMessage = e.Message;
+                ErrorMessage = e.Message;
+            }
         }
 
 

--- a/MarkdownMonster/Windows/TableEditor/TableEditor.xaml.cs
+++ b/MarkdownMonster/Windows/TableEditor/TableEditor.xaml.cs
@@ -292,10 +292,6 @@ namespace MarkdownMonster.Windows
             {
                 data = parser.ParseMarkdownToData(html);
             }
-            else if (html.Contains("-|-") || html.Contains("- | -") || html.Contains(""))
-            {
-                data = parser.ParseMarkdownToData(html);
-            }
             else if (html.Contains("-+-"))
             {
                 data = parser.ParseMarkdownGridTableToData(html);

--- a/MarkdownMonster/_Classes/Utilities/GitHelper.cs
+++ b/MarkdownMonster/_Classes/Utilities/GitHelper.cs
@@ -1002,12 +1002,14 @@ namespace MarkdownMonster.Utilities
         {
             if (ex == null)
                 this.ErrorMessage = string.Empty;
+            else
+            {
+                Exception e = ex;
+                if (checkInner)
+                    e = e.GetBaseException();
 
-            Exception e = ex;
-            if (checkInner)
-                e = e.GetBaseException();
-
-            ErrorMessage = e.Message;
+                ErrorMessage = e.Message;
+            }
         }
         #endregion
 

--- a/MarkdownMonster/_Classes/Utilities/HtmlPackager.cs
+++ b/MarkdownMonster/_Classes/Utilities/HtmlPackager.cs
@@ -673,12 +673,14 @@ namespace Westwind.HtmlPackager
         {
             if (ex == null)
                 this.ErrorMessage = string.Empty;
+            else
+            {
+                Exception e = ex;
+                if (checkInner)
+                    e = e.GetBaseException();
 
-            Exception e = ex;
-            if (checkInner)
-                e = e.GetBaseException();
-
-            ErrorMessage = e.Message;
+                ErrorMessage = e.Message;
+            }
         }
         #endregion
     }

--- a/MarkdownMonster/_Classes/Utilities/HtmlPackager.cs
+++ b/MarkdownMonster/_Classes/Utilities/HtmlPackager.cs
@@ -345,8 +345,10 @@ namespace Westwind.HtmlPackager
                 {
                     if (url.StartsWith("http"))
                     {
-                        var http = new WebClient();
-                        cssText = http.DownloadString(url);
+                        using (var http = new WebClient())
+                        {
+                            cssText = http.DownloadString(url);
+                        }
                     }
                     else if (url.StartsWith("file:///"))
                     {
@@ -359,8 +361,10 @@ namespace Westwind.HtmlPackager
                         url = uri.AbsoluteUri;
                         if (url.StartsWith("http") && url.Contains("://"))
                         {
-                            var http = new WebClient();
-                            cssText = http.DownloadString(url);
+                            using (var http = new WebClient())
+                            {
+                                cssText = http.DownloadString(url);
+                            }
                         }
                         else
                             cssText = File.ReadAllText(uri.LocalPath);
@@ -418,8 +422,10 @@ namespace Westwind.HtmlPackager
                 {
                     if (url.StartsWith("http"))
                     {
-                        var http = new WebClient();
-                        scriptData = http.DownloadData(url);
+                        using (var http = new WebClient())
+                        {
+                            scriptData = http.DownloadData(url);
+                        }
                     }
                     else if (url.StartsWith("file:///"))
                     {
@@ -432,8 +438,10 @@ namespace Westwind.HtmlPackager
                         url = uri.AbsoluteUri;
                         if (url.StartsWith("http") && url.Contains("://"))
                         {
-                            var http = new WebClient();
-                            scriptData = http.DownloadData(url);
+                            using (var http = new WebClient())
+                            {
+                                scriptData = http.DownloadData(url);
+                            }
                         }
                         else
                             scriptData = File.ReadAllBytes(uri.LocalPath);
@@ -483,9 +491,11 @@ namespace Westwind.HtmlPackager
                 {
                     if (url.StartsWith("http"))
                     {
-                        var http = new WebClient();
-                        imageData = http.DownloadData(url);
-                        contentType = http.ResponseHeaders[System.Net.HttpResponseHeader.ContentType];
+                        using (var http = new WebClient())
+                        {
+                            imageData = http.DownloadData(url);
+                            contentType = http.ResponseHeaders[System.Net.HttpResponseHeader.ContentType];
+                        }
                     }
                     else if (url.StartsWith("file:///"))
                     {
@@ -499,8 +509,10 @@ namespace Westwind.HtmlPackager
                         
                         if (uri.Scheme.StartsWith("http"))
                         {
-                            var http = new WebClient();
-                            imageData = http.DownloadData(uri.AbsoluteUri);
+                            using (var http = new WebClient())
+                            {
+                                imageData = http.DownloadData(uri.AbsoluteUri);
+                            }
                         }
                         else
                             imageData = File.ReadAllBytes(uri.LocalPath);
@@ -581,9 +593,11 @@ namespace Westwind.HtmlPackager
                 {
                     if (url.StartsWith("http"))
                     {
-                        var http = new WebClient();
-                        linkData = http.DownloadData(url);
-                        contentType = http.ResponseHeaders[HttpResponseHeader.ContentType];
+                        using (var http = new WebClient())
+                        {
+                            linkData = http.DownloadData(url);
+                            contentType = http.ResponseHeaders[HttpResponseHeader.ContentType];
+                        }
                     }
                     else if (url.StartsWith("file:///"))
                     {
@@ -602,8 +616,10 @@ namespace Westwind.HtmlPackager
                         url = uri.AbsoluteUri;
                         if (url.StartsWith("http") && url.Contains("://"))
                         {
-                            var http = new WebClient();
-                            linkData = http.DownloadData(url);
+                            using (var http = new WebClient())
+                            {
+                                linkData = http.DownloadData(url);
+                            }
                         }
                         else
                             linkData = File.ReadAllBytes(uri.LocalPath);

--- a/MarkdownMonster/_Classes/Utilities/HtmlToPdfGeneration.cs
+++ b/MarkdownMonster/_Classes/Utilities/HtmlToPdfGeneration.cs
@@ -296,12 +296,14 @@ namespace MarkdownMonster
         {
             if (ex == null)
                 ErrorMessage = string.Empty;
+            else
+            {
+                Exception e = ex;
+                if (checkInner)
+                    e = e.GetBaseException();
 
-            Exception e = ex;
-            if (checkInner)
-                e = e.GetBaseException();
-
-            ErrorMessage = e.Message;
+                ErrorMessage = e.Message;
+            }
         }
         #endregion
 

--- a/MarkdownMonster/_Classes/Utilities/SpellChecker.cs
+++ b/MarkdownMonster/_Classes/Utilities/SpellChecker.cs
@@ -175,14 +175,16 @@ namespace MarkdownMonster.Utilities
                         Directory.CreateDirectory(basePath);
 
                     var dicFile = Path.Combine(basePath, language + ".dic");
-                    var web = new WebClient();
-                    web.DownloadFile(new Uri(url), dicFile);
+                    using (var web = new WebClient())
+                    {
+                        web.DownloadFile(new Uri(url), dicFile);
 
-                    var affFile = dicFile.Replace(".dic", ".aff");
-                    url = url.Replace(".dic", ".aff");
-                    web.DownloadFile(new Uri(url), affFile);
+                        var affFile = dicFile.Replace(".dic", ".aff");
+                        url = url.Replace(".dic", ".aff");
+                        web.DownloadFile(new Uri(url), affFile);
 
-                    return File.Exists(dicFile) && File.Exists(affFile);
+                        return File.Exists(dicFile) && File.Exists(affFile);
+                    }
                 }
             }
             catch(Exception ex)
@@ -203,9 +205,6 @@ namespace MarkdownMonster.Utilities
             mmApp.Model.Window.ShowStatusProgress($"Downloading dictionary license for {language}");
 
             //download license
-            var wc = new WebClient();
-            wc.Encoding = Encoding.UTF8;
-
             var url = $"https://raw.githubusercontent.com/wooorm/dictionaries/main/dictionaries/{language}/license";
             
             var dd = DictionaryDownloads.FirstOrDefault(dx => dx.Code == language);
@@ -215,7 +214,11 @@ namespace MarkdownMonster.Utilities
             string md;
             try
             {
-                md = wc.DownloadString(url);
+                using (var wc = new WebClient())
+                {
+                    wc.Encoding = Encoding.UTF8;
+                    md = wc.DownloadString(url);
+                }
             }
             catch
             {

--- a/MarkdownMonster/_Classes/Utilities/mmFileUtils.cs
+++ b/MarkdownMonster/_Classes/Utilities/mmFileUtils.cs
@@ -548,7 +548,7 @@ namespace MarkdownMonster
             {
                 string exe = mmApp.Configuration.Images.ImageViewer;
                 if (!string.IsNullOrEmpty(exe))
-                    Process.Start(new ProcessStartInfo(exe, $"\"{imageFile}\""));
+                    Process.Start(new ProcessStartInfo(exe, $"\"{Path.GetFullPath(imageFile)}\""));
                 else
                 {
                     Process.Start(new ProcessStartInfo {FileName = imageFile, UseShellExecute = true});

--- a/MarkdownMonster/_Classes/Utilities/mmFileUtils.cs
+++ b/MarkdownMonster/_Classes/Utilities/mmFileUtils.cs
@@ -500,7 +500,7 @@ namespace MarkdownMonster
                 return false;
 
 
-            if (imageFileOrUrl.StartsWith("https://") || imageFileOrUrl.StartsWith("https://"))
+            if (imageFileOrUrl.StartsWith("http://") || imageFileOrUrl.StartsWith("https://"))
             {
                 var imageFile = HttpUtils.DownloadImageToFile(imageFileOrUrl);
 

--- a/MarkdownMonster/_Classes/Utilities/mmFileUtils.cs
+++ b/MarkdownMonster/_Classes/Utilities/mmFileUtils.cs
@@ -517,7 +517,7 @@ namespace MarkdownMonster
             {
                 string exe = mmApp.Configuration.Images.ImageEditor;
                 if (!string.IsNullOrEmpty(exe))
-                    Process.Start(new ProcessStartInfo(exe, $"\"{imageFileOrUrl}\""));
+                    Process.Start(new ProcessStartInfo(exe, $"\"{Path.GetFullPath(imageFileOrUrl)}\""));
                 else
                 {
                     Process.Start(new ProcessStartInfo


### PR DESCRIPTION
1. Minor fixes in the mmFileUtils file: Typo - the scheme is repeated. When a markdown file contains an image using forward slashes, it's not possible to open them in a named editor like mspaint because the path is not recognised when presented as an argument to the process. GetFullPath() fixes the image path.
2. Several null reference checks throughout.
3. Proper disposal of WebClient and FileStream.