### PR TITLE
Fix View menu preview toggle items

### DIFF
--- a/MarkdownMonster/_Classes/Commands/AppCommands.cs
+++ b/MarkdownMonster/_Classes/Commands/AppCommands.cs
@@ -1120,9 +1120,15 @@ namespace MarkdownMonster
                     return;
 
                 if (action == "ExternalPreviewWindow")
+                {
                     Model.Configuration.PreviewMode = MarkdownMonster.PreviewModes.ExternalPreviewWindow;
+                    Model.IsExternalPreview = true;
+                }
                 else
+                {
                     Model.Configuration.PreviewMode = MarkdownMonster.PreviewModes.InternalPreview;
+                    Model.IsInternalPreview = true;
+                }
 
                 Model.IsPreviewBrowserVisible = true;
 


### PR DESCRIPTION
The View menu toggle items (External / Internal preview) did not work properly. E.g. if you select the External menu item and then select it a second time.